### PR TITLE
Create packaging for libnetfilter_conntrack, use version 1.1.0 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "upstream"]
+	path = upstream
+	url = https://github.com/sailfishos-mirror/libnetfilter_conntrack

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # libnetfilter_conntrack
+
+libnetfilter_conntrack is a userspace library providing a programming 
+interface (API) to the in-kernel connection tracking state table.
+
+https://netfilter.org/projects/libnetfilter_conntrack

--- a/rpm/libnetfilter_conntrack.spec
+++ b/rpm/libnetfilter_conntrack.spec
@@ -1,0 +1,54 @@
+Name:           libnetfilter_conntrack
+Version:        1.1.0
+Release:        1
+Summary:        Netfilter conntrack userspace library
+License:        GPLv2
+URL:            https://github.com/sailfishos/libnetfilter_conntrack
+Source0:        %{name}-%{version}.tar.bz2
+
+BuildRequires:  gnupg2
+BuildRequires:  kernel-headers
+BuildRequires:  pkgconfig(libmnl) >= 1.0.3
+BuildRequires:  pkgconfig(libnfnetlink) >= 1.0.1
+BuildRequires:  make autoconf automake libtool
+
+%description
+libnetfilter_conntrack is a userspace library providing a programming 
+interface (API) to the in-kernel connection tracking state table.
+
+%package        devel
+Summary:        Netfilter conntrack userspace library
+Requires:       %{name} = %{version}-%{release}, libnfnetlink-devel >= 1.0.1
+Requires:       kernel-headers
+
+%description    devel
+libnetfilter_conntrack is a userspace library providing a programming
+interface (API) to the in-kernel connection tracking state table.
+
+%prep
+%autosetup -p1 -n %{name}-%{version}/upstream
+
+%build
+%autogen
+autoreconf -vi
+%configure --disable-static --disable-rpath
+
+%make_build
+
+%install
+%make_install
+find $RPM_BUILD_ROOT -type f -name "*.la" -delete
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%license COPYING
+%{_libdir}/*.so.*
+
+%files devel
+%{_libdir}/*.so
+%{_libdir}/pkgconfig/*.pc
+%dir %{_includedir}/libnetfilter_conntrack
+%{_includedir}/libnetfilter_conntrack/*.h


### PR DESCRIPTION
Create initial packaging, use the latest tagged version 1.1.0.

Required by iptables update to 1.8.11 https://github.com/sailfishos/iptables/pull/3